### PR TITLE
v1, broken tests

### DIFF
--- a/notebooks/Dev Notebook.ipynb
+++ b/notebooks/Dev Notebook.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -12,6 +12,9 @@
     "from tenzing.core.model_implementations import *\n",
     "from tenzing.core.typesets import infer_type, traverse_relation_graph, build_relation_graph\n",
     "from tenzing.core.model_implementations.typesets import tenzing_standard\n",
+    "from tenzing.utils import singleton\n",
+    "from tenzing.core.models import tenzing_model\n",
+    "from tenzing.core.mixins import uniqueSummaryMixin\n",
     "\n",
     "import pandas.api.types as pdt\n",
     "from collections import Counter\n",
@@ -29,9 +32,132 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<function tenzing_float.summarization_op at 0x1077a2ae8>\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'n_unique': 3,\n",
+       " 'p_unique': 0.75,\n",
+       " 'nunique': 2.0,\n",
+       " 'mean': 1.3333333333333333,\n",
+       " 'std': 0.5773502691896257,\n",
+       " 'var': 0.3333333333333333,\n",
+       " 'max': 2.0,\n",
+       " 'min': 1.0,\n",
+       " 'median': 1.0,\n",
+       " 'kurt': nan,\n",
+       " 'skew': 1.7320508075688785,\n",
+       " 'sum': 4.0,\n",
+       " 'mad': 0.4444444444444444,\n",
+       " 'quantile_5': 1.0,\n",
+       " 'quantile_25': 1.0,\n",
+       " 'quantile_50': 1.0,\n",
+       " 'quantile_75': 1.5,\n",
+       " 'quantile_95': 1.9,\n",
+       " 'range': 1.0,\n",
+       " 'iqr': 0.5,\n",
+       " 'cv': 0.4330127018922193,\n",
+       " 'n_records': 4,\n",
+       " 'memory_size': (112,)}"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@singleton.singleton_object\n",
+    "class tenzing_float(uniqueSummaryMixin, tenzing_model):\n",
+    "    \"\"\"**Float** implementation of :class:`tenzing.core.models.tenzing_model`.\n",
+    "\n",
+    "    >>> x = pd.Series([1.0, 2.5, 5.0, np.nan])\n",
+    "    >>> x in tenzing_float\n",
+    "    True\n",
+    "    \"\"\"\n",
+    "    def contains_op(self, series):\n",
+    "        if not pdt.is_float_dtype(series):\n",
+    "            return False\n",
+    "        # TODO: are we sure we want this to depend on integer?\n",
+    "        elif series in tenzing_integer:\n",
+    "            return False\n",
+    "        else:\n",
+    "            return True\n",
+    "\n",
+    "    def cast_op(self, series):\n",
+    "        return series.astype(float)\n",
+    "\n",
+    "    def summarization_op(self, series):\n",
+    "        aggregates = ['nunique', 'mean', 'std', 'var', 'max', 'min', 'median', 'kurt', 'skew', 'sum', 'mad']\n",
+    "        summary = series.agg(aggregates).to_dict()\n",
+    "\n",
+    "        quantiles = [0.05, 0.25, 0.5, 0.75, 0.95]\n",
+    "        for percentile, value in series.quantile(quantiles).to_dict().items():\n",
+    "            summary[\"quantile_{:d}\".format(int(percentile * 100))] = value\n",
+    "\n",
+    "        summary[\"range\"] = summary[\"max\"] - summary[\"min\"]\n",
+    "        summary[\"iqr\"] = summary[\"quantile_75\"] - summary[\"quantile_25\"]\n",
+    "        summary[\"cv\"] = summary[\"std\"] / summary[\"mean\"] if summary[\"mean\"] else np.NaN\n",
+    "\n",
+    "        # TODO: move to common\n",
+    "        summary['n_records'] = series.shape[0]\n",
+    "        summary['memory_size'] = series.memory_usage(index=True, deep=True),\n",
+    "\n",
+    "\n",
+    "        # TODO: only calculations for histogram, not the plotting\n",
+    "        # summary['image'] = plotting.histogram(series)\n",
+    "        return summary\n",
+    "\n",
+    "series = pd.Series([1.0, 2.0, np.nan, 1.0])\n",
+    "tenzing_float.summarize(series)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'n_unique': 2, 'p_unique': 1.0}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "uniqueSummaryMixin().summarization_op(series)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'series' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-2-e3a0c7a68773>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      9\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     10\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 11\u001b[0;31m \u001b[0mcontains_op\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mseries\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'series' is not defined"
+     ]
+    }
+   ],
    "source": [
     "def contains_op(series):\n",
     "    if pdt.is_integer_dtype(series):\n",

--- a/src/tenzing/core/mixins/__init__.py
+++ b/src/tenzing/core/mixins/__init__.py
@@ -1,0 +1,3 @@
+from tenzing.core.mixins.inf_mixin import infMixin
+from tenzing.core.mixins.option_mixin import optionMixin
+from tenzing.core.mixins.unique_mixin import uniqueSummaryMixin

--- a/src/tenzing/core/mixins/option_mixin.py
+++ b/src/tenzing/core/mixins/option_mixin.py
@@ -4,10 +4,6 @@ class optionMixin:
     When creating a custom Tenzing type simply inherit from optionMixin to add
     automatic support for missing values.
 
-    >>> @singleton.singleton_object
-    >>> class tenzing_timestamp(optionMixin, tenzing_model):
-    >>>     // Implementation
-
     """
     is_option = True
 
@@ -31,9 +27,9 @@ class optionMixin:
         notna_series = series[~idx].infer_objects() if idx.any() else series
         return self.contains_op(notna_series)
 
-    def summarize(self, series):
+    def summarization_op(self, series):
+        summary = {}
         idx = series.isna()
-        summary = self.summarization_op(series[~idx])
 
         summary['na_count'] = idx.values.sum()
         summary['perc_na'] = summary['na_count'] / series.shape[0] if series.shape[0] > 0 else 0

--- a/src/tenzing/core/mixins/unique_mixin.py
+++ b/src/tenzing/core/mixins/unique_mixin.py
@@ -1,0 +1,25 @@
+class uniqueSummaryMixin:
+    """Mixin adding missing value support to tenzing types
+
+    When creating a custom Tenzing type simply inherit from optionMixin to add
+    automatic support for missing values.
+
+    """
+
+    def get_series(self, series):
+        return series
+
+    def summarization_op(self, series):
+        n_unique = len(set(series.values))
+        return {"n_unique": n_unique, "perc_unique": float(n_unique) / len(series)}
+
+
+"""
+    def warnings(summary):
+        messages = []
+        if summary["n_unique"] == 1:
+            messages.append("n_unique:const")
+        if summary["p_unique"] == 1.0:
+            messages.append("n_unique:unique")
+        return messages
+"""

--- a/src/tenzing/core/model_implementations/types/tenzing_float.py
+++ b/src/tenzing/core/model_implementations/types/tenzing_float.py
@@ -2,13 +2,13 @@ import pandas.api.types as pdt
 import numpy as np
 
 from tenzing.core import tenzing_model
-from tenzing.core.mixins.option_mixin import optionMixin
+from tenzing.core.mixins import optionMixin, uniqueSummaryMixin
 from tenzing.core.model_implementations.types.tenzing_integer import tenzing_integer
 from tenzing.utils import singleton
 
 
 @singleton.singleton_object
-class tenzing_float(optionMixin, tenzing_model):
+class tenzing_float(optionMixin, uniqueSummaryMixin, tenzing_model):
     """**Float** implementation of :class:`tenzing.core.models.tenzing_model`.
 
     >>> x = pd.Series([1.0, 2.5, 5.0, np.nan])
@@ -28,7 +28,7 @@ class tenzing_float(optionMixin, tenzing_model):
         return series.astype(float)
 
     def summarization_op(self, series):
-        aggregates = ['nunique', 'mean', 'std', 'var', 'max', 'min', 'median', 'kurt', 'skew', 'sum', 'mad']
+        aggregates = ['mean', 'std', 'var', 'max', 'min', 'median', 'kurt', 'skew', 'sum', 'mad']
         summary = series.agg(aggregates).to_dict()
 
         quantiles = [0.05, 0.25, 0.5, 0.75, 0.95]

--- a/src/tenzing/utils/singleton.py
+++ b/src/tenzing/utils/singleton.py
@@ -17,6 +17,7 @@ class Singleton(ABCMeta):
     _instances = {}
 
     def __call__(cls, *args, **kwargs):
+
         if cls not in cls._instances:
             cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
         return cls._instances[cls]
@@ -27,6 +28,27 @@ class Singleton(ABCMeta):
             return True
         else:
             return isinstance(instance.__class__, mcs)
+
+    def wrap_summary(func, bases=[]):
+        """Return a wrapped instance method"""
+
+        @staticmethod
+        def outer(series):
+            summary = {}
+            for base in bases[:-1]:  # last is always the base class
+                summary.update(base.summarization_op(None, series))
+            summary.update(func(None, series))
+
+            return summary
+
+        return outer
+
+    def __new__(cls, name, bases, attrs):
+        """If the class has a 'get_series' or 'summarize' method, wrap it"""
+        if "summarization_op" in attrs:
+            attrs["summarization_op"] = cls.wrap_summary(attrs["summarization_op"], bases)
+
+        return super(Singleton, cls).__new__(cls, name, bases, attrs)
 
 
 def singleton_object(cls):

--- a/tests/test_summarization.py
+++ b/tests/test_summarization.py
@@ -24,7 +24,7 @@ def test_integer_missing_summary(tenzing_type=tenzing_integer):
         'min': 0,
         'n_records': 6,
         'n_zeros': 1,
-        'perc_zeros': 1.0 / 5.0,
+        'perc_zeros': 1.0 / 6.0,
         'na_count': 1,
         'perc_na': 1.0 / 6.0,
     }
@@ -36,7 +36,8 @@ def test_integer_missing_summary(tenzing_type=tenzing_integer):
 def test_float_missing_summary(tenzing_type=tenzing_float):
     test_series = pd.Series([0.0, 1.0, 2.0, 3.0, 4.0, np.nan])
     correct_output = {
-        'nunique': 5,
+        'n_unique': 6,
+        'perc_unique': 1.0,
         'median': 2,
         'mean': 2,
         'std': pytest.approx(1.58113, 0.00001),


### PR DESCRIPTION
I was trying to integrate your summarize closure implementation from mister-jones but belatedly realized it also breaks Options (at least as I've done it). Previously, the optionMixin was responsible for invoking subsequent summarization_op's so that missing values were removed.

I'm pretty new to Meta classes though so it's been a fair bit of stumbling around. Not sure if this has any useful code in it except the skeleton of a uniqueMixin. 